### PR TITLE
Fixed the issue when saving settings

### DIFF
--- a/includes/integration.php
+++ b/includes/integration.php
@@ -17,7 +17,11 @@ class WeDevs_WC_Tracking_Integration extends WC_Integration {
         $this->init_form_fields();
         $this->init_settings();
 
-        add_action( 'woocommerce_update_options_integration', array($this, 'process_admin_options') );
+        // Save settings if the we are in the right section
+        if ( isset( $_POST[ 'section' ] ) && $this->id === $_POST[ 'section' ] ) {
+            add_action( 'woocommerce_update_options_integration', array($this, 'process_admin_options') );
+        }
+
         add_action( 'woocommerce_product_options_reviews', array($this, 'product_options') );
         add_action( 'woocommerce_process_product_meta', array($this, 'product_options_save'), 10, 2 );
 


### PR DESCRIPTION
Hi Tareq!

My client use this plugin on his site, together with the WooCommerce Ambassador plugin which also uses the WC_Integration class.

The problem is that when the settings of the Ambassador plugin are saved, the action `woocommerce_update_options_integration` is triggered in your plugin are triggered as well. And since the textarea fields of your plugin are missing on the Ambassador settings page, I get the following notice and all the fields of your plugin are reset to blank: `Notice: Undefined index: woocommerce_wc_conv_tracking_cart in [...]/wp-content/plugins/woocommerce-conversion-tracking/includes/integration.php on line 79`.

The solution was simple and I already implemented it. Just one IF statement was missing to check the hidden field of section. So the action is only triggered we are in the right section as well to update the settings.

I'd love to see this issue merged into master :)
