### PR TITLE
Make integration name translation lazy, fixing #3

### DIFF
--- a/includes/class-abstract-integration.php
+++ b/includes/class-abstract-integration.php
@@ -65,11 +65,12 @@ abstract class WCCT_Integration {
 
     /**
      * Get the integration name
+     * Lazy translation so that we don't trigger autoload of the woocommerce-conversion-tracking textdomain
      *
      * @return string
      */
     public function get_name() {
-        return $this->name;
+        return __( $this->name, 'woocommerce-conversion-tracking' );
     }
 
     /**

--- a/includes/integrations/class-integration-custom.php
+++ b/includes/integrations/class-integration-custom.php
@@ -10,7 +10,7 @@ class WCCT_Integration_Custom extends WCCT_Integration {
      */
     function __construct() {
         $this->id           = 'custom';
-        $this->name         = __( 'Custom', 'woocommerce-conversion-tracking' );
+        $this->name         = 'Custom';
         $this->enabled      = true;
         $this->supports     = array(
             'checkout',

--- a/includes/integrations/class-integration-facebook.php
+++ b/includes/integrations/class-integration-facebook.php
@@ -10,7 +10,7 @@ class WCCT_Integration_Facebook extends WCCT_Integration {
      */
     function __construct() {
         $this->id        = 'facebook';
-        $this->name      = __( 'Facebook', 'woocommerce-conversion-tracking' );
+        $this->name      = 'Facebook';
         $this->enabled   = true;
         $this->supports  = array(
             'add_to_cart',

--- a/includes/integrations/class-integration-google.php
+++ b/includes/integrations/class-integration-google.php
@@ -10,7 +10,7 @@ class WCCT_Integration_Google extends WCCT_Integration {
      */
     function __construct() {
         $this->id           = 'adwords';
-        $this->name         = __( 'Google Ads', 'woocommerce-conversion-tracking' );
+        $this->name         = 'Google Ads';
         $this->enabled      = true;
         $this->supports     = array(
             'checkout',

--- a/includes/integrations/class-integration-twitter.php
+++ b/includes/integrations/class-integration-twitter.php
@@ -10,7 +10,7 @@ class WCCT_Integration_Twitter extends WCCT_Integration {
      */
     function __construct() {
         $this->id       = 'twitter';
-        $this->name     = __( 'Twitter', 'woocommerce-conversion-tracking' );
+        $this->name     = 'Twitter';
         $this->enabled  = true;
         $this->supports = array(
             'checkout',


### PR DESCRIPTION
### Summary  
This change updates the way integration names are translated to comply with WordPress 6.7’s stricter translation-loading rules.  

Previously the class constructors used `__()` directly on the `name` property. That triggered `_load_textdomain_just_in_time` notices because it forced translations before `init`. WordPress 6.7+ logs these as warnings.  

### What Changed  
- Added a `get_name()` method that translates the stored source string lazily.  
- Constructors now assign the plain string (e.g. `'Twitter'`) instead of a translated one.  
- All UI should call `$integration->get_name()` so translations are loaded at the right time.  

### Why  
These notices have been spamming my debug logs, and my marketer unfortunately uses this plugin. This solution keeps the strings translatable without triggering warnings in WordPress 6.7+.  

### Impact  
- Removes log spam.  
- Preserves localization support.  
- No functional change except that code must use `get_name()` rather than reading the protected `$name` property directly.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Integration names now consistently display in your selected language (Facebook, Google Ads, Twitter, Custom), resolving inconsistent or missing translations in some views.

- Refactor
  - Centralized lazy translation to occur when names are retrieved, reducing early loading overhead and improving startup performance.
  - Simplified integration constructors by storing plain names while ensuring translation at display time.

- Chores
  - Minor internal cleanups with no impact on settings or workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->