### PR TITLE
Fix: Defer Conversion Tracking class and localization initialization

### DIFF
--- a/conversion-tracking.php
+++ b/conversion-tracking.php
@@ -76,8 +76,9 @@ class WeDevs_WC_Conversion_Tracking {
 
         $this->define_constants();
         $this->init_hooks();
-        $this->includes();
-        $this->init_classes();
+        // Defer heavy includes and class instantiation until WP 'init'
+        add_action( 'init', array( $this, 'includes' ), 10 );
+        add_action( 'init', array( $this, 'init_classes' ), 20 );
 
         register_activation_hook( __FILE__, array( $this, 'activate' ) );
 
@@ -191,7 +192,8 @@ class WeDevs_WC_Conversion_Tracking {
         add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'plugin_action_links' ) );
         add_action( 'admin_notices', array( $this, 'happy_addons_ads_banner' ) );
 
-        $this->init_tracker();
+        // Defer tracker initialization until after localization and integrations
+        add_action( 'init', array( $this, 'init_tracker' ), 30 );
     }
 
     /**
@@ -363,8 +365,8 @@ function wcct_init() {
     return WeDevs_WC_Conversion_Tracking::init();
 }
 
-// WeDevs_WC_Conversion_Tracking
-wcct_init();
+// Instantiate plugin on 'plugins_loaded' to allow localization to be registered
+add_action( 'plugins_loaded', 'wcct_init' );
 
 /**
  * Manage Capability

--- a/conversion-tracking.php
+++ b/conversion-tracking.php
@@ -76,9 +76,7 @@ class WeDevs_WC_Conversion_Tracking {
 
         $this->define_constants();
         $this->init_hooks();
-        // Defer heavy includes and class instantiation until WP 'init'
-        add_action( 'init', array( $this, 'includes' ), 10 );
-        add_action( 'init', array( $this, 'init_classes' ), 20 );
+        $this->includes();
 
         register_activation_hook( __FILE__, array( $this, 'activate' ) );
 
@@ -187,13 +185,11 @@ class WeDevs_WC_Conversion_Tracking {
 
         add_action( 'plugins_loaded', array( $this, 'plugin_upgrades' ) );
         add_action( 'init', array( $this, 'localization_setup' ) );
+        add_action( 'init', array( $this, 'init_classes' ) );
 
         add_action( 'admin_notices', array( $this, 'check_woocommerce_exist' ) );
         add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'plugin_action_links' ) );
         add_action( 'admin_notices', array( $this, 'happy_addons_ads_banner' ) );
-
-        // Defer tracker initialization until after localization and integrations
-        add_action( 'init', array( $this, 'init_tracker' ), 30 );
     }
 
     /**
@@ -202,6 +198,7 @@ class WeDevs_WC_Conversion_Tracking {
      * @return void
      */
     public function init_classes() {
+        $this->init_tracker();
         $this->container['ajax']                = new WCCT_Ajax();
         $this->container['event_dispatcher']    = new WCCT_Event_Dispatcher();
         $this->container['admin']               = new WCCT_Admin();
@@ -365,8 +362,8 @@ function wcct_init() {
     return WeDevs_WC_Conversion_Tracking::init();
 }
 
-// Instantiate plugin on 'plugins_loaded' to allow localization to be registered
-add_action( 'plugins_loaded', 'wcct_init' );
+// WeDevs_WC_Conversion_Tracking
+wcct_init();
 
 /**
  * Manage Capability


### PR DESCRIPTION
Closes https://github.com/getdokan/woocommerce-conversion-tracking/issues/64

Changelog
- Fixed an issue where the woocommerce-conversion-tracking text domain was loaded too early, causing PHP notices.

- Deferred class and integration initialization to the init hook to ensure proper localization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deferred plugin startup to run during WordPress initialization and ensured the tracking component is activated early in that stage, improving compatibility with other plugins, startup reliability, and overall initialization sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->